### PR TITLE
Adding process_searched_ldap.yml

### DIFF
--- a/relationships/process_searched_ldap.yml
+++ b/relationships/process_searched_ldap.yml
@@ -16,6 +16,12 @@ security_events:
     audit_sub_category: null
     log_channel: Microsoft-Windows-LDAP-Client/Debug
     log_provider: Microsoft-Windows-LDAP-Client
+  - event_id: LdapSearch
+    name: LdapSearch
+    platform: Windows
+    audit_category: null
+    log_channel: DeviceEvents
+    log_provider: Microsoft Defender for Endpoint
 references:
   - 
 notes:

--- a/relationships/process_searched_ldap.yml
+++ b/relationships/process_searched_ldap.yml
@@ -3,7 +3,7 @@ contributors:
   - Hamza OUADIÂ @Cyb3rSn0rlax
 attack:
   data_source: Process
-  data_component: ldap access
+  data_component: null
 behavior:
   source: process 
   relationship: searched

--- a/relationships/process_searched_ldap.yml
+++ b/relationships/process_searched_ldap.yml
@@ -1,0 +1,22 @@
+name: Process searched LDAP
+contributors:
+  - Hamza OUADIÂ @Cyb3rSn0rlax
+attack:
+  data_source: Process
+  data_component: ldap access
+behavior:
+  source: process 
+  relationship: searched
+  target: ldap
+security_events:
+  - event_id: 30
+    name: EventID(30)
+    platform: Windows
+    audit_category: null
+    audit_sub_category: null
+    log_channel: Microsoft-Windows-LDAP-Client/Debug
+    log_provider: Microsoft-Windows-LDAP-Client
+references:
+  - 
+notes:
+  - Host-based ETW provieder for LDAP search filter performed by a process. This event provides valuable data like PID, search filter and attributes.


### PR DESCRIPTION
Addin process searched ldap relationship. a Host-based ETW provider for LDAP search filter performed by a process. This event provides valuable data like PID, search filter and attributes.
This is particularly useful for detecting internal discovery techniques performed by tools like SharpHound and Rubeus...etc