### PR TITLE
Adding Logon Process Trusted

### DIFF
--- a/relationships/logon_process_trusted.yml
+++ b/relationships/logon_process_trusted.yml
@@ -1,0 +1,25 @@
+relationship_id: REL-2022-0187
+name: Logon Process Trusted
+contributors:
+- Hamza OUADIA @Cyb3rSn0rlax
+attack:
+  data_source: null
+  data_component: null
+behavior:
+  source: logon process
+  relationship: trusted
+  target: null
+security_events:
+- event_id: 4611
+  name: A trusted logon process has been registered with the Local Security Authority.
+  platform: Windows
+  audit_category: System
+  audit_sub_category: Security System Extension
+  log_channel: Security
+  log_provider: Microsoft-Windows-Security-Auditing
+references:
+- https://docs.microsoft.com/en-us/windows/security/threat-protection/auditing/event-4611
+- https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=4611
+notes:
+- This event indicates that a logon process has registered with the Local Security Authority (LSA). 
+- At the technical level, the event does not come from the registration of a trusted logon process, but from a confirmation that the process is a trusted logon process. If it is a trusted logon process, the event generates.

--- a/scripts/generate_uuid.py
+++ b/scripts/generate_uuid.py
@@ -1,0 +1,24 @@
+import glob
+import os
+import re
+
+current_directory = os.path.dirname(__file__)
+relationships_directory = os.path.join(current_directory, '../relationships')
+max_id=0
+num_id = []
+relationships_files = glob.glob(os.path.join(relationships_directory, "[!_]*.yml"))
+for relationship_file in relationships_files:
+    file = open(relationship_file,'r+')
+    first_line = file.readlines()[0].rstrip() # read first line
+    if re.search("^relationship_id\:\sREL\-202[\d]{1}\-\d{4}", first_line): # If file already has an ID
+        search = re.search("^relationship_id\:\sREL\-202[\d]{1}\-(.*?)$", first_line) # Grab it
+        num_id.append(search.group(1))
+# Convert strings to integers
+for i in range(0, len(num_id)):
+    num_id[i] = int(num_id[i])
+# Get max ID in list
+for n in num_id:
+    if n > max_id: max_id = n
+# Generate relationship_id
+count = max_id+1
+print('relationship_id: REL-2022-' + '0'*(4 - len(str(count))) + str(count))


### PR DESCRIPTION
## Adding Logon Process Trusted
The event id 4611 for example can be helpful in detecting rogue logon process like Rubeus' `User32LogonProcesss` with triple 'S'

```yaml
relationship_id: REL-2022-0187
name: Logon Process Trusted
contributors:
- Hamza OUADIA @Cyb3rSn0rlax
attack:
  data_source: null
  data_component: null
behavior:
  source: logon process
  relationship: trusted
  target: null
security_events:
- event_id: 4611
  name: A trusted logon process has been registered with the Local Security Authority.
  platform: Windows
  audit_category: System
  audit_sub_category: Security System Extension
  log_channel: Security
  log_provider: Microsoft-Windows-Security-Auditing
references:
- https://docs.microsoft.com/en-us/windows/security/threat-protection/auditing/event-4611
- https://www.ultimatewindowssecurity.com/securitylog/encyclopedia/event.aspx?eventid=4611
notes:
- This event indicates that a logon process has registered with the Local Security Authority (LSA). 
- At the technical level, the event does not come from the registration of a trusted logon process, but from a confirmation that the process is a trusted logon process. If it is a trusted logon process, the event generates.
```
## Adding script to generate a UUID for future contributions
The script generate_uuid.py will generate a new UUID based on the already existing ones
```python
import glob
import os
import re

current_directory = os.path.dirname(__file__)
relationships_directory = os.path.join(current_directory, '../relationships')
max_id=0
num_id = []
relationships_files = glob.glob(os.path.join(relationships_directory, "[!_]*.yml"))
for relationship_file in relationships_files:
    file = open(relationship_file,'r+')
    first_line = file.readlines()[0].rstrip() # read first line
    if re.search("^relationship_id\:\sREL\-202[\d]{1}\-\d{4}", first_line): # If file already has an ID
        search = re.search("^relationship_id\:\sREL\-202[\d]{1}\-(.*?)$", first_line) # Grab it
        num_id.append(search.group(1))
# Convert strings to integers
for i in range(0, len(num_id)):
    num_id[i] = int(num_id[i])
# Get max ID in list
for n in num_id:
    if n > max_id: max_id = n
# Generate relationship_id
count = max_id+1
print('relationship_id: REL-2022-' + '0'*(4 - len(str(count))) + str(count))
```
- [ ] Add support for generic year value, currently supports 2022