### PR TITLE
fixing missing characters in yml

### DIFF
--- a/relationships/process_deleted_registry.yml
+++ b/relationships/process_deleted_registry.yml
@@ -45,7 +45,7 @@ security_events:
   audit_sub_category: Registry
   log_source: Microsoft-Windows-Security-Auditing
   filter_in:
-  -ActionType: Registry value deleted
+  - ActionType: Registry value deleted
   event_version:
   - '0'
 - event_id: 4660

--- a/relationships/user_added_firewall_rule_from_ip.yml
+++ b/relationships/user_added_firewall_rule_from_ip.yml
@@ -8,7 +8,7 @@ behavior:
   relationship: added firewall rule from
   target: ip
 security_events:
-  event_id: cloudtrail
+- event_id: cloudtrail
   name: cloudtrail
   platform: aws
   log_source: cloudtrail


### PR DESCRIPTION
Added a missing '-' character to a .yml file.
Added a missing ' ' character to a .yml file.
Problem came from attempting to parse the .yml using any common schema batch loader for relationships.
Was using a golang parser which first converts it to json and then a struct definition.

The missing '-' character created a conflict where 'security_events' was both an array of maps and a map.
Map version only occurs in one file so preferred the array of maps.

Missing ' ' character resulted in the field being named as '-ActionType' instead of 'ActionType'.  Also prevented it from falling under 'filter_in'

Automatic generation of schema should be as follows:
```
ossem-dm/relationships:
{
    "attack": {
        "data_component": "",
        "data_source": ""
    },
    "behavior": {
        "relationship": "",
        "source": "",
        "target": ""
    },
    "contributors": [
        ""
    ],
    "name": "",
    "note": null,
    "notes": [
        ""
    ],
    "references": [
        ""
    ],
    "relationship_id": "",
    "security_events": [
        {
            "audit_category": "",
            "audit_sub_category": "",
            "event_id": "",
            "event_version": [
                ""
            ],
            "filter_in": [
                {
                    "ActionType": "",
                    "EventType": "",
                    "ObjectType": "",
                    "OperationType": "",
                    "eventName": "",
                    "eventType": ""
                }
            ],
            "log_channel": "",
            "log_provider": "",
            "log_source": "",
            "name": "",
            "platform": ""
        }
    ]
}
```