### PR TITLE
Removing typo where references had a double dash

### DIFF
--- a/relationships/_all_ossem_relationships.yml
+++ b/relationships/_all_ossem_relationships.yml
@@ -3095,7 +3095,7 @@
     channel: System
     log_source: EventLog
   references:
-  - - https://learn.microsoft.com/en-us/sysinternals/downloads/sysmon#event-id-4-sysmon-service-state-changed
+  - https://learn.microsoft.com/en-us/sysinternals/downloads/sysmon#event-id-4-sysmon-service-state-changed
   notes: null
 - relationship_id: REL-2022-0095
   name: Process modified Firewall rule
@@ -4636,7 +4636,7 @@
     - '0'
     - '1'
   references:
-  - - https://learn.microsoft.com/en-us/sysinternals/downloads/sysmon#event-id-3-network-connection
+  - https://learn.microsoft.com/en-us/sysinternals/downloads/sysmon#event-id-3-network-connection
   notes: null
 - relationship_id: REL-2022-0143
   name: Process modified Process

--- a/relationships/process_connected_to_host.yml
+++ b/relationships/process_connected_to_host.yml
@@ -37,5 +37,5 @@ security_events:
   - '0'
   - '1'
 references:
-- - https://learn.microsoft.com/en-us/sysinternals/downloads/sysmon#event-id-3-network-connection
+- https://learn.microsoft.com/en-us/sysinternals/downloads/sysmon#event-id-3-network-connection
 notes: null

--- a/relationships/service_stopped.yml
+++ b/relationships/service_stopped.yml
@@ -25,5 +25,5 @@ security_events:
   channel: System
   log_source: EventLog
 references:
-- - https://learn.microsoft.com/en-us/sysinternals/downloads/sysmon#event-id-4-sysmon-service-state-changed
+- https://learn.microsoft.com/en-us/sysinternals/downloads/sysmon#event-id-4-sysmon-service-state-changed
 notes: null


### PR DESCRIPTION
Just back fixing a typo again.
Typo caused the references to appear as an array of array of strings when the intent was an array of strings on the references field.